### PR TITLE
feat: add support for language queryParam

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Just pass your query as the path, and you will be redirected to the most relevan
 - [`a.stro.cc/vercel`](https://a.stro.cc/vercel) => `https://docs.astro.build/en/guides/deploy/vercel/`
 - [`a.stro.cc/islands`](https://a.stro.cc/islands) => `https://docs.astro.build/en/concepts/islands/`
 - [`a.stro.cc/github%20pages`](https://a.stro.cc/github%20pages) => `https://docs.astro.build/en/guides/deploy/github/`
-- [`a.stro.cc/islands&lang=fr`](a.stro.cc/islands&lang=fr) => `https://docs.astro.build/fr/guides/deploy/vercel/`
+- [`a.stro.cc/islands?lang=fr`](a.stro.cc/islands&lang=fr) => `https://docs.astro.build/fr/guides/deploy/vercel/`
 
 ## Tip
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Just pass your query as the path, and you will be redirected to the most relevan
 - [`a.stro.cc/vercel`](https://a.stro.cc/vercel) => `https://docs.astro.build/en/guides/deploy/vercel/`
 - [`a.stro.cc/islands`](https://a.stro.cc/islands) => `https://docs.astro.build/en/concepts/islands/`
 - [`a.stro.cc/github%20pages`](https://a.stro.cc/github%20pages) => `https://docs.astro.build/en/guides/deploy/github/`
+- [`a.stro.cc/islands&lang=fr`](a.stro.cc/islands&lang=fr) => `https://docs.astro.build/fr/guides/deploy/vercel/`
 
-## Tip! 
+## Tip
 
 Use this as a site shortcut in Chrome!
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Just pass your query as the path, and you will be redirected to the most relevan
 - [`a.stro.cc/vercel`](https://a.stro.cc/vercel) => `https://docs.astro.build/en/guides/deploy/vercel/`
 - [`a.stro.cc/islands`](https://a.stro.cc/islands) => `https://docs.astro.build/en/concepts/islands/`
 - [`a.stro.cc/github%20pages`](https://a.stro.cc/github%20pages) => `https://docs.astro.build/en/guides/deploy/github/`
-- [`a.stro.cc/islands?lang=fr`](a.stro.cc/islands&lang=fr) => `https://docs.astro.build/fr/guides/deploy/vercel/`
+- [`a.stro.cc/fr/vercel`](a.stro.cc/fr/vercel) => `https://docs.astro.build/fr/guides/deploy/vercel/`
 
 ## Tip
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -13,10 +13,11 @@ export default async function handler(request: Request) {
     // to get the most relevant search result for our domain.
     const searchURL = new URL(engine);
     const query = new URL(request.url).searchParams.get('q');
+    const lang = new URL(request.url).searchParams.get('lang') ?? 'en';
     if (!query) {
-        return redirect(domain);
+        return redirect(new URL(`${domain}/${lang}`));
     }
-    searchURL.searchParams.set('q', `! site:${domain} ${query}`);
+    searchURL.searchParams.set('q', `! site:${domain}/${lang} ${query}`);
     try {
         const html = await fetch(searchURL, { method: 'GET' }).then(res => res.text());
         // DuckDuckGo rewrites the request to a client-side redirect for tracking.

--- a/api/index.ts
+++ b/api/index.ts
@@ -15,9 +15,9 @@ export default async function handler(request: Request) {
     const query = new URL(request.url).searchParams.get('q');
     const lang = new URL(request.url).searchParams.get('lang') ?? 'en';
     if (!query) {
-        return redirect(new URL(`${domain}/${lang}`));
+        return redirect(new URL(`${domain}${lang}`));
     }
-    searchURL.searchParams.set('q', `! site:${domain}/${lang} ${query}`);
+    searchURL.searchParams.set('q', `! site:${domain}${lang} ${query}`);
     try {
         const html = await fetch(searchURL, { method: 'GET' }).then(res => res.text());
         // DuckDuckGo rewrites the request to a client-side redirect for tracking.

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,10 @@
     { "source": "/", "destination": "https://github.com/withastro/wormhole" }
   ],
   "rewrites": [
-    { "source": "/:path*", "destination": "/api/index?q=:path*" },
     {
-      "source": "/:path*/:language",
-      "destination": "/api/index?q=:path&lang=:language"
-    }
+      "source": "/:query/:language",
+      "destination": "/api/index?q=:query&lang=:language"
+    },
+    { "source": "/:path*", "destination": "/api/index?q=:path*" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   ],
   "rewrites": [
     {
-      "source": "/:query/:language",
+      "source": "/:language/:query",
       "destination": "/api/index?q=:query&lang=:language"
     },
     { "source": "/:path*", "destination": "/api/index?q=:path*" }

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,11 @@
   "redirects": [
     { "source": "/", "destination": "https://github.com/withastro/wormhole" }
   ],
-  "rewrites": [{ "source": "/:path*", "destination": "/api/index?q=:path*" }]
+  "rewrites": [
+    { "source": "/:path*", "destination": "/api/index?q=:path*" },
+    {
+      "source": "/:path*/:language",
+      "destination": "/api/index?q=:path&lang=:language"
+    }
+  ]
 }


### PR DESCRIPTION
Adds support for languages. You can do something like `a.stro.cc/fr/vercel`.

To make it better, we could also add an enum type to make sure the language is a valid language in Astro Docs

Main motivation was to make it work with [the Raycast extension](https://github.com/raycast/extensions/pull/8708) I'm building that supports multiple languages. And will add the correct language and fallbacks under the hood

Preview URL: https://wormhole-git-add-lang-elianvancutsem.vercel.app/